### PR TITLE
Add NestJS starter project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+node_modules
+.dist
+.DS_Store
+dist
+
+# local env files
+.env

--- a/README.md
+++ b/README.md
@@ -1,2 +1,24 @@
 # AITest
-Let's have fun With Mister AI
+
+This repository contains a minimal NestJS starter project implemented in TypeScript.
+
+## Getting Started
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Run the application in development mode:
+   ```bash
+   npm run start:dev
+   ```
+3. Build for production:
+   ```bash
+   npm run build
+   ```
+4. Start the built application:
+   ```bash
+   npm start
+   ```
+
+The app listens on **http://localhost:3000** and returns `Hello World!` for the root route.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "aitest",
+  "version": "1.0.0",
+  "description": "Learning NestJS",
+  "main": "dist/main.js",
+  "scripts": {
+    "start": "node dist/main.js",
+    "start:dev": "ts-node -r tsconfig-paths/register src/main.ts",
+    "build": "tsc -p tsconfig.build.json"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "type": "commonjs",
+  "dependencies": {
+    "@nestjs/common": "^10.0.0",
+    "@nestjs/core": "^10.0.0",
+    "@nestjs/platform-express": "^10.0.0",
+    "reflect-metadata": "^0.1.13",
+    "rxjs": "^7.8.1"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "ts-node": "^10.9.1",
+    "tsconfig-paths": "^4.2.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get } from '@nestjs/common';
+import { AppService } from './app.service';
+
+@Controller()
+export class AppController {
+  constructor(private readonly appService: AppService) {}
+
+  @Get()
+  getHello(): string {
+    return this.appService.getHello();
+  }
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { AppController } from './app.controller';
+import { AppService } from './app.service';
+
+@Module({
+  imports: [],
+  controllers: [AppController],
+  providers: [AppService],
+})
+export class AppModule {}

--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class AppService {
+  getHello(): string {
+    return 'Hello World!';
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,9 @@
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  await app.listen(3000);
+}
+
+bootstrap();

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "declaration": true,
+    "sourceMap": true
+  },
+  "exclude": [
+    "node_modules",
+    "test",
+    "dist"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "declaration": true,
+    "removeComments": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "ES2022",
+    "sourceMap": true,
+    "outDir": "dist",
+    "baseUrl": "./",
+    "incremental": true,
+    "strict": true
+  },
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- setup NestJS skeleton in TypeScript
- document install and run steps

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails to resolve modules)*

------
https://chatgpt.com/codex/tasks/task_e_6842e32a38d48321a69d3895e3355a62